### PR TITLE
chore: exit alpha

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "erc20-payment": "0.0.1",


### PR DESCRIPTION
this will end-up with `0.0.2` as stable release