### PR TITLE
chore: remove initialize network capabilities from prepareCalls

### DIFF
--- a/.changeset/lucky-friends-shout.md
+++ b/.changeset/lucky-friends-shout.md
@@ -1,0 +1,5 @@
+---
+"@gelatonetwork/smartwallet": patch
+---
+
+chore: remove initialize network capabilities from prepareCalls

--- a/src/actions/estimate.ts
+++ b/src/actions/estimate.ts
@@ -4,7 +4,6 @@ import type { GelatoSmartAccount } from "../accounts/index.js";
 import type { Payment } from "../payment/index.js";
 import type { Quote } from "../relay/rpc/interfaces/index.js";
 import { walletPrepareCalls } from "../relay/rpc/prepareCalls.js";
-import { initializeNetworkCapabilities } from "../relay/rpc/utils/networkCapabilities.js";
 import type { GelatoWalletClient } from "./index.js";
 
 /**
@@ -23,8 +22,6 @@ export async function estimate<
   parameters: { payment: Payment; calls: Call[] }
 ): Promise<Quote> {
   const { payment, calls } = structuredClone(parameters);
-
-  await initializeNetworkCapabilities(client);
 
   const { context } = await walletPrepareCalls(client, {
     payment,

--- a/src/actions/prepare.ts
+++ b/src/actions/prepare.ts
@@ -4,7 +4,6 @@ import type { GelatoSmartAccount } from "../accounts/index.js";
 import type { Payment } from "../payment/index.js";
 import { walletPrepareCalls } from "../relay/rpc/index.js";
 import type { WalletPrepareCallsResponse } from "../relay/rpc/interfaces/index.js";
-import { initializeNetworkCapabilities } from "../relay/rpc/utils/networkCapabilities.js";
 import type { GelatoWalletClient } from "./index.js";
 
 /**
@@ -22,8 +21,6 @@ export async function prepare<
   parameters: { payment: Payment; calls: Call[]; nonceKey?: bigint }
 ): Promise<WalletPrepareCallsResponse> {
   const { payment, calls, nonceKey } = parameters;
-
-  await initializeNetworkCapabilities(client);
 
   return await walletPrepareCalls(client, {
     calls,


### PR DESCRIPTION
`networkCapabilities` is no longer used since we don't maintain a whitelist of delegate addresses anymore