### PR TITLE
feat: support trust wallet

### DIFF
--- a/.changeset/young-pandas-create.md
+++ b/.changeset/young-pandas-create.md
@@ -1,0 +1,5 @@
+---
+"@gelatonetwork/smartwallet": patch
+---
+
+feat: support trust wallet

--- a/examples/trust-wallet-sponsored/.env.example
+++ b/examples/trust-wallet-sponsored/.env.example
@@ -1,0 +1,2 @@
+SPONSOR_API_KEY="Get your sponsor api key at https://app.gelato.network/relay"
+PRIVATE_KEY="0x<PRIVATE_KEY>" # Optional

--- a/examples/trust-wallet-sponsored/README.md
+++ b/examples/trust-wallet-sponsored/README.md
@@ -1,0 +1,22 @@
+# TrustWallet Sponsored Payment Example
+
+## Prerequisites
+
+- Node.js >= 23
+- pnpm >= 10.8.1
+
+## Quick Start
+
+1. Install dependencies:
+
+```bash
+pnpm install
+```
+
+## Running Examples
+
+1. Run the example:
+
+```bash
+pnpm dev
+```

--- a/examples/trust-wallet-sponsored/package.json
+++ b/examples/trust-wallet-sponsored/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "trust-wallet-sponsored-payment",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@gelatonetwork/smartwallet": "workspace:*",
+    "viem": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "dotenv": "^16.5.0",
+    "tsx": "^4.19.4",
+    "typescript": "catalog:"
+  }
+}

--- a/examples/trust-wallet-sponsored/src/index.ts
+++ b/examples/trust-wallet-sponsored/src/index.ts
@@ -1,0 +1,92 @@
+import {
+  type GelatoTaskStatus,
+  createGelatoSmartWalletClient,
+  sponsored
+} from "@gelatonetwork/smartwallet";
+import { trustWallet } from "@gelatonetwork/smartwallet/accounts";
+import "dotenv/config";
+import { type Hex, createPublicClient, createWalletClient, http } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { baseSepolia } from "viem/chains";
+
+const sponsorApiKey = process.env.SPONSOR_API_KEY;
+
+if (!sponsorApiKey) {
+  throw new Error("SPONSOR_API_KEY is not set");
+}
+
+const privateKey = (process.env.PRIVATE_KEY ?? generatePrivateKey()) as Hex;
+const owner = privateKeyToAccount(privateKey);
+
+const publicClient = createPublicClient({
+  chain: baseSepolia,
+  transport: http()
+});
+
+(async () => {
+  const account = await trustWallet({
+    owner,
+    client: publicClient
+  });
+
+  console.log("Account address:", account.address);
+
+  const client = createWalletClient({
+    account,
+    chain: baseSepolia,
+    transport: http()
+  });
+
+  const swc = await createGelatoSmartWalletClient(client, {
+    apiKey: sponsorApiKey
+  });
+
+  console.log("Preparing transaction...");
+  const startPrepare = performance.now();
+  const preparedCalls = await swc.prepare({
+    payment: sponsored(sponsorApiKey),
+    calls: [
+      {
+        to: "0xEEeBe2F778AA186e88dCf2FEb8f8231565769C27",
+        data: "0xd09de08a",
+        value: 0n
+      }
+    ]
+  });
+  const endPrepare = performance.now();
+  console.log(`Took ${(endPrepare - startPrepare).toFixed(2)}ms to prepare your request.`);
+
+  console.log("Sending transaction...");
+  const startSend = performance.now();
+  const startTimestamp = Date.now();
+  const response = await swc.send({
+    preparedCalls
+  });
+  const endSend = performance.now();
+  console.log(
+    `Took ${(endSend - startSend).toFixed(2)}ms to send your request. Your Gelato id is: ${response.id}`
+  );
+
+  // Listen for events
+  response.on("submitted", (status: GelatoTaskStatus) => {
+    const end = performance.now();
+    console.log(`Transaction submitted: ${status.transactionHash}`);
+    console.log(`Time from sending to onchain submission: ${(end - startSend).toFixed(2)}ms`);
+  });
+  response.on("success", async (status: GelatoTaskStatus) => {
+    console.log(`Transaction successful: ${status.transactionHash}`);
+    const blockTimestamp = await publicClient
+      .getTransactionReceipt({ hash: status.transactionHash as `0x${string}` })
+      .then(({ blockHash }) => publicClient.getBlock({ blockHash: blockHash }))
+      .then((block) => Number(block.timestamp) * 1000);
+    const latency = blockTimestamp - startTimestamp;
+    console.log(`Latency to get transaction included: ${latency}ms`);
+    process.exit(0);
+  });
+  response.on("error", (error: Error) => {
+    const end = performance.now();
+    console.error(`Transaction failed: ${error.message}`);
+    console.log(`Time from sending to error: ${(end - startSend).toFixed(2)}ms`);
+    process.exit(1);
+  });
+})();

--- a/examples/trust-wallet-sponsored/src/index.ts
+++ b/examples/trust-wallet-sponsored/src/index.ts
@@ -5,7 +5,7 @@ import {
 } from "@gelatonetwork/smartwallet";
 import { trustWallet } from "@gelatonetwork/smartwallet/accounts";
 import "dotenv/config";
-import { type Hex, createPublicClient, createWalletClient, http } from "viem";
+import { http, type Hex, createPublicClient, createWalletClient } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { baseSepolia } from "viem/chains";
 

--- a/examples/trust-wallet-sponsored/tsconfig.json
+++ b/examples/trust-wallet-sponsored/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 2.29.3
       '@vitest/coverage-v8':
         specifier: 3.1.3
-        version: 3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
+        version: 3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
       prool:
         specifier: 0.0.24
         version: 0.0.24
@@ -64,10 +64,10 @@ importers:
         version: 2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4)
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   examples/custom-sponsored:
     dependencies:
@@ -230,13 +230,13 @@ importers:
         version: 18.3.7(@types/react@18.3.23)
       '@vitejs/plugin-react':
         specifier: 4.4.1
-        version: 4.4.1(vite@6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
+        version: 4.4.1(vite@6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   examples/react-wagmi:
     dependencies:
@@ -276,7 +276,7 @@ importers:
         version: 18.3.7(@types/react@18.3.23)
       '@vitejs/plugin-react':
         specifier: 4.4.1
-        version: 4.4.1(vite@6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
+        version: 4.4.1(vite@6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
       '@wagmi/cli':
         specifier: latest
         version: 2.3.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -288,7 +288,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   examples/safe-sponsored:
     dependencies:
@@ -324,6 +324,28 @@ importers:
       '@types/node':
         specifier: latest
         version: 22.15.29
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.5.0
+      tsx:
+        specifier: ^4.19.4
+        version: 4.19.4
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
+  examples/trust-wallet-sponsored:
+    dependencies:
+      '@gelatonetwork/smartwallet':
+        specifier: workspace:*
+        version: link:../../src
+      viem:
+        specifier: 'catalog:'
+        version: 2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4)
+    devDependencies:
+      '@types/node':
+        specifier: latest
+        version: 24.0.3
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -2683,6 +2705,9 @@ packages:
 
   '@types/node@24.0.1':
     resolution: {integrity: sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==}
+
+  '@types/node@24.0.3':
+    resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
 
   '@types/prop-types@15.7.14':
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
@@ -7987,14 +8012,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -8007,7 +8032,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       '@types/yargs': 15.0.19
       chalk: 4.1.2
 
@@ -8016,7 +8041,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -9680,7 +9705,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
 
   '@types/debug@4.1.12':
     dependencies:
@@ -9704,7 +9729,7 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
 
   '@types/node@12.20.55': {}
 
@@ -9717,6 +9742,10 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/node@24.0.1':
+    dependencies:
+      undici-types: 7.8.0
+
+  '@types/node@24.0.3':
     dependencies:
       undici-types: 7.8.0
 
@@ -9741,11 +9770,11 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -9757,18 +9786,18 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@vitejs/plugin-react@4.4.1(vite@6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))':
+  '@vitejs/plugin-react@4.4.1(vite@6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
       '@babel/core': 7.27.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.4)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.27.4)
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))':
+  '@vitest/coverage-v8@3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -9782,7 +9811,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9793,13 +9822,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))':
+  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.1.3':
     dependencies:
@@ -11248,7 +11277,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -12238,7 +12267,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -12259,13 +12288,13 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       jest-util: 29.7.0
 
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12282,7 +12311,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -14049,13 +14078,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@3.1.3(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0):
+  vite-node@3.1.3(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14070,7 +14099,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0):
+  vite@6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.5(picomatch@4.0.2)
@@ -14079,16 +14108,16 @@ snapshots:
       rollup: 4.41.1
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
       fsevents: 2.3.3
       terser: 5.40.0
       tsx: 4.19.4
       yaml: 2.8.0
 
-  vitest@3.1.3(@types/debug@4.1.12)(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0):
+  vitest@3.1.3(@types/debug@4.1.12)(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
+      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.0
       '@vitest/runner': 3.1.3
       '@vitest/snapshot': 3.1.3
@@ -14105,12 +14134,12 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.0
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
-      vite-node: 3.1.3(@types/node@24.0.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+      vite-node: 3.1.3(@types/node@24.0.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 24.0.1
+      '@types/node': 24.0.3
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/abis/trustWallet.ts
+++ b/src/abis/trustWallet.ts
@@ -1,0 +1,5 @@
+import { parseAbi } from "viem";
+
+export const bizGuardAbi = parseAbi([
+  "function accountNonce(address account) view returns (uint256)"
+]);

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -1,15 +1,17 @@
 import type { Abi } from "viem";
 import type { SmartAccount } from "viem/account-abstraction";
 import type { PrivateKeyAccount } from "viem/accounts";
+import type { WalletEncoding, WalletType } from "../wallet/index.js";
 
 export { custom } from "./custom/index.js";
 export { gelato } from "./gelato/index.js";
 export { kernel } from "./kernel/index.js";
 export { okx } from "./okx/index.js";
 export { safe } from "./safe/index.js";
+export { trustWallet } from "./trustWallet/index.js";
 
-export type GelatoSmartAccountSCWEncoding = "erc7821" | "safe" | "okx" | "erc7579";
-export type GelatoSmartAccountSCWType = "gelato" | "kernel" | "safe" | "okx" | "custom";
+export type GelatoSmartAccountSCWEncoding = `${WalletEncoding}`;
+export type GelatoSmartAccountSCWType = `${WalletType}`;
 export type GelatoSmartAccountSCW =
   | {
       type: Exclude<GelatoSmartAccountSCWType, "custom">;

--- a/src/accounts/trustWallet/index.ts
+++ b/src/accounts/trustWallet/index.ts
@@ -1,0 +1,249 @@
+import type {
+  Account,
+  Address,
+  Hex,
+  Prettify,
+  PrivateKeyAccount,
+  TypedData,
+  TypedDataDefinition
+} from "viem";
+import { BaseError, isAddressEqual } from "viem";
+import type { SmartAccount, SmartAccountImplementation } from "viem/account-abstraction";
+import {
+  entryPoint07Abi,
+  entryPoint07Address,
+  getUserOperationHash,
+  toSmartAccount
+} from "viem/account-abstraction";
+import {
+  getChainId,
+  getCode,
+  readContract,
+  signAuthorization as viem_signAuthorization,
+  signMessage as viem_signMessage,
+  signTypedData as viem_signTypedData
+} from "viem/actions";
+import { encodeCalls } from "viem/experimental/erc7821";
+import { verifyAuthorization } from "viem/utils";
+
+import { bizGuardAbi as abi } from "../../abis/trustWallet.js";
+import { delegationCode } from "../../constants/index.js";
+import { lowercase } from "../../utils/index.js";
+import type { GelatoSmartAccountExtension } from "../index.js";
+
+export type TrustWalletSmartAccountImplementation<eip7702 extends boolean = boolean> =
+  SmartAccountImplementation<typeof entryPoint07Abi, "0.7", GelatoSmartAccountExtension, eip7702>;
+
+export type TrustWalletSmartAccountParameters<eip7702 extends boolean = true> = {
+  client: TrustWalletSmartAccountImplementation<eip7702>["client"];
+  owner: Account;
+  authorization?: TrustWalletSmartAccountImplementation<eip7702>["authorization"];
+  eip7702?: eip7702;
+};
+
+export type TrustWalletSmartAccountReturnType = Prettify<
+  SmartAccount<TrustWalletSmartAccountImplementation>
+>;
+
+export async function trustWallet<eip7702 extends boolean = true>(
+  parameters: TrustWalletSmartAccountParameters<eip7702>
+): Promise<TrustWalletSmartAccountReturnType> {
+  const { client, owner, eip7702: _eip7702, authorization: _authorization } = parameters;
+
+  const eip7702 = _eip7702 ?? true;
+  const erc4337 = false;
+
+  if (!eip7702) {
+    throw new Error("EIP-7702 must be enabled. No support for non-EIP-7702 accounts.");
+  }
+
+  const entryPoint = {
+    abi: entryPoint07Abi,
+    address: entryPoint07Address,
+    version: "0.7"
+  } as const;
+
+  let deployed = false;
+  let chainId: number;
+
+  const getMemoizedChainId = async () => {
+    if (chainId) return chainId;
+    chainId = client.chain ? client.chain.id : await getChainId(client);
+    return chainId;
+  };
+
+  const { authorization } = await (async () => {
+    if (_authorization) {
+      return {
+        authorization: _authorization
+      };
+    }
+
+    return {
+      authorization: {
+        account: owner,
+        address: trustWalletDelegationAddress(await getMemoizedChainId())
+      }
+    };
+  })();
+
+  const isDeployed = async () => {
+    if (deployed) {
+      return true;
+    }
+
+    const code = await getCode(client, { address: owner.address });
+
+    deployed = Boolean(
+      code?.length &&
+        code.length > 0 &&
+        lowercase(code) === lowercase(delegationCode(authorization.address))
+    );
+
+    return deployed;
+  };
+
+  const account = (await toSmartAccount({
+    abi,
+    client,
+    extend: {
+      abi,
+      owner,
+      eip7702,
+      erc4337,
+      scw: { type: "trustWallet", encoding: "trustWallet", version: "1.0" } as const
+    },
+    entryPoint,
+    authorization: authorization as {
+      account: PrivateKeyAccount;
+      address: Address;
+    },
+    async signAuthorization() {
+      const _isDeployed = await isDeployed();
+
+      if (!_isDeployed) {
+        if (
+          !isAddressEqual(
+            authorization.address,
+            trustWalletDelegationAddress(await getMemoizedChainId())
+          )
+        ) {
+          throw new Error(
+            "EIP-7702 authorization delegation address does not match account implementation address"
+          );
+        }
+
+        const auth = await viem_signAuthorization(client, {
+          ...authorization,
+          chainId: await getMemoizedChainId()
+        });
+
+        const verified = await verifyAuthorization({
+          authorization: auth,
+          address: owner.address
+        });
+
+        if (!verified) {
+          throw new Error("Authorization verification failed");
+        }
+
+        return auth;
+      }
+
+      return undefined;
+    },
+    async decodeCalls() {
+      // TODO
+      throw new BaseError("Decoding calls is not implemented");
+    },
+
+    async encodeCalls(calls, opData?: Hex) {
+      return encodeCalls(calls, opData);
+    },
+
+    async getNonce(): Promise<bigint> {
+      return readContract(client, {
+        abi,
+        address: trustWalletBizGuardAddress(await getMemoizedChainId()),
+        functionName: "accountNonce",
+        args: [owner.address]
+      });
+    },
+    async getAddress() {
+      return owner.address;
+    },
+
+    async getFactoryArgs() {
+      return { factory: "0x7702", factoryData: "0x" };
+    },
+
+    async signMessage(parameters) {
+      const { message } = parameters;
+
+      return viem_signMessage(client, {
+        account: owner,
+        message
+      });
+    },
+
+    async signTypedData(parameters) {
+      const { domain, types, primaryType, message } = parameters as TypedDataDefinition<
+        TypedData,
+        string
+      >;
+
+      return viem_signTypedData(client, {
+        domain,
+        message,
+        primaryType,
+        types,
+        account: owner
+      });
+    },
+
+    async getStubSignature() {
+      return "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
+    },
+
+    async signUserOperation(parameters) {
+      const { chainId = await getMemoizedChainId(), ...userOperation } = parameters;
+
+      const hash = getUserOperationHash({
+        userOperation: {
+          ...userOperation,
+          sender: userOperation.sender ?? (await this.getAddress()),
+          signature: "0x"
+        },
+        entryPointAddress: entryPoint.address,
+        entryPointVersion: entryPoint.version,
+        chainId
+      });
+
+      const signature = await viem_signMessage(client, {
+        account: owner,
+        message: { raw: hash }
+      });
+
+      return signature;
+    }
+  })) as unknown as TrustWalletSmartAccountReturnType;
+
+  // Required since `toSmartAccount` overwrites any provided `isDeployed` implementation
+  account.isDeployed = isDeployed;
+
+  return account;
+}
+
+/// Constants
+const TRUST_WALLET_V1_0_DELEGATION_ADDRESS: Address = "0xD2e28229F6f2c235e57De2EbC727025A1D0530FB";
+const TRUST_WALLET_BIZ_GUARD_ADDRESS: Address = "0x6067203E59E681396335940c4F2Caf6b002815Bc";
+
+const trustWalletDelegationAddress = (chainId: number): Address =>
+  chainId === 1 || chainId === 56
+    ? TRUST_WALLET_V1_0_DELEGATION_ADDRESS
+    : "0x895362E5B5dC18B71e78018552c8E3D4e1955b0c"; // Deployed by Gelato
+
+const trustWalletBizGuardAddress = (chainId: number): Address =>
+  chainId === 1 || chainId === 56
+    ? TRUST_WALLET_BIZ_GUARD_ADDRESS
+    : "0x221cb5b4fe1d76f9f7277de67e3a580ebdd194a7"; // Deployed by Gelato

--- a/src/relay/rpc/prepareCalls.ts
+++ b/src/relay/rpc/prepareCalls.ts
@@ -3,7 +3,6 @@ import type { Chain, Transport } from "viem";
 import type { GelatoSmartAccount } from "../../accounts/index.js";
 import type { GelatoWalletClient } from "../../actions/index.js";
 import { api } from "../../constants/index.js";
-import { WalletType } from "../../wallet/index.js";
 import type {
   Capabilities,
   GelatoCapabilities,
@@ -28,7 +27,7 @@ export const walletPrepareCalls = async <
 
   const capabilities: Capabilities = <GelatoCapabilities>{
     wallet: {
-      type: client.account.scw.type === "okx" ? WalletType.OKX : undefined,
+      type: client.account.scw.type,
       encoding: client.account.scw.encoding,
       version: client.account.scw.version
     },

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -1,12 +1,18 @@
 export enum WalletType {
-  OKX = "okx"
+  Gelato = "gelato",
+  Kernel = "kernel",
+  Safe = "safe",
+  OKX = "okx",
+  TrustWallet = "trustWallet",
+  Custom = "custom"
 }
 
 export enum WalletEncoding {
   ERC7821 = "erc7821",
   Safe = "safe",
   OKX = "okx",
-  ERC7579 = "erc7579"
+  ERC7579 = "erc7579",
+  TrustWallet = "trustWallet"
 }
 
 export interface WalletDetails {


### PR DESCRIPTION
contributes to ACC-136
- adds trust wallet account type
- passes walletType in `prepareCalls` for all wallets (This will get rejected by current RPC param validation on gateway) 

* https://github.com/gelatodigital/relay-api-gateway/pull/346) has to be deployed first