### PR TITLE
chore: remove passing of apiKey from sponsored payment

### DIFF
--- a/examples/custom-sponsored/src/index.ts
+++ b/examples/custom-sponsored/src/index.ts
@@ -58,7 +58,7 @@ const publicClient = createPublicClient({
   });
 
   const response = await swc.execute({
-    payment: sponsored(gelatoApiKey),
+    payment: sponsored(),
     calls: [
       {
         to: "0xEEeBe2F778AA186e88dCf2FEb8f8231565769C27",

--- a/examples/estimates/src/index.ts
+++ b/examples/estimates/src/index.ts
@@ -36,7 +36,7 @@ const publicClient = createPublicClient({
   });
 
   const response = await swc.estimate({
-    payment: sponsored(gelatoApiKey),
+    payment: sponsored(),
     calls: [
       {
         to: "0xEEeBe2F778AA186e88dCf2FEb8f8231565769C27",

--- a/examples/kernel-sponsored/src/index.ts
+++ b/examples/kernel-sponsored/src/index.ts
@@ -43,7 +43,7 @@ const publicClient = createPublicClient({
   });
 
   const response = await swc.execute({
-    payment: sponsored(gelatoApiKey),
+    payment: sponsored(),
     calls: [
       {
         to: "0xEEeBe2F778AA186e88dCf2FEb8f8231565769C27",

--- a/examples/light-account-sponsored/src/index.ts
+++ b/examples/light-account-sponsored/src/index.ts
@@ -41,7 +41,7 @@ const client = createPublicClient({
     bundlerTransport: http()
   }).extend(
     gelatoBundlerActions({
-      payment: sponsored(gelatoApiKey),
+      payment: sponsored(),
       // payment: erc20(paymentToken),
       // payment: native(),
       encoding: WalletEncoding.LightAccount

--- a/examples/nonces/src/index.ts
+++ b/examples/nonces/src/index.ts
@@ -48,7 +48,7 @@ const main = async () => {
   // Regular `execute` call key without `nonce` or `nonceKey` specified.
   // This defaults to `nonceKey` zero.
   const response1 = await swc.execute({
-    payment: sponsored(gelatoApiKey),
+    payment: sponsored(),
     calls
   });
 
@@ -62,12 +62,12 @@ const main = async () => {
   // To execute transactions in parallel, a different `nonceKey` can be specified for each call.
   const responses2 = await Promise.all([
     swc.execute({
-      payment: sponsored(gelatoApiKey),
+      payment: sponsored(),
       calls,
       nonceKey: 10n
     }),
     swc.execute({
-      payment: sponsored(gelatoApiKey),
+      payment: sponsored(),
       calls,
       nonceKey: 20n
     })
@@ -85,12 +85,12 @@ const main = async () => {
 
   const responses3 = await Promise.all([
     swc.execute({
-      payment: sponsored(gelatoApiKey),
+      payment: sponsored(),
       calls,
       nonce
     }),
     swc.execute({
-      payment: sponsored(gelatoApiKey),
+      payment: sponsored(),
       calls,
       nonce: nonce + 1n // this transaction will execute after the first one
     })

--- a/examples/okx-sponsored/src/index.ts
+++ b/examples/okx-sponsored/src/index.ts
@@ -42,7 +42,7 @@ const publicClient = createPublicClient({
   });
 
   const response = await swc.execute({
-    payment: sponsored(gelatoApiKey),
+    payment: sponsored(),
     calls: [
       {
         to: "0xEEeBe2F778AA186e88dCf2FEb8f8231565769C27",

--- a/examples/permissionless-adapter/src/index.ts
+++ b/examples/permissionless-adapter/src/index.ts
@@ -41,7 +41,7 @@ const client = createPublicClient({
     }
   }).extend(
     gelatoBundlerActions({
-      payment: sponsored(gelatoApiKey),
+      payment: sponsored(),
       // payment: erc20(paymentToken),
       // payment: native(),
       encoding: WalletEncoding.Safe

--- a/examples/react-vite/src/providers.tsx
+++ b/examples/react-vite/src/providers.tsx
@@ -65,7 +65,6 @@ const WalletInfoComponent = () => {
   const [transactionStatus, setTransactionStatus] = useState<TransactionStatus | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const { address: walletAddress } = useAccount();
-  const gelatoApiKey = import.meta.env.VITE_GELATO_API_KEY;
 
   const executeTransaction = async () => {
     if (!client) return;
@@ -74,7 +73,7 @@ const WalletInfoComponent = () => {
     try {
       const payment =
         paymentType === "sponsored"
-          ? sponsored(gelatoApiKey)
+          ? sponsored()
           : paymentType === "erc20"
             ? erc20(erc20TokenAddress)
             : native();

--- a/examples/react-wagmi/src/App.tsx
+++ b/examples/react-wagmi/src/App.tsx
@@ -6,8 +6,6 @@ import {
 import { useCallback, useState } from "react";
 import { useAccount, useConnect, useDisconnect } from "wagmi";
 
-const gelatoApiKey = import.meta.env.VITE_GELATO_API_KEY;
-
 function App() {
   const account = useAccount();
   const { connectors, connect, status, error } = useConnect();
@@ -20,7 +18,7 @@ function App() {
     data: taskId,
     isPending
   } = useSendTransaction({
-    payment: sponsored(gelatoApiKey)
+    payment: sponsored()
   });
 
   const { data: receipt } = useWaitForTransactionReceipt({

--- a/examples/safe-sponsored/src/index.ts
+++ b/examples/safe-sponsored/src/index.ts
@@ -41,7 +41,7 @@ const publicClient = createPublicClient({
   const swc = await createGelatoSmartWalletClient(client, { apiKey: gelatoApiKey });
 
   const response = await swc.execute({
-    payment: sponsored(gelatoApiKey),
+    payment: sponsored(),
     calls: [
       {
         to: "0xEEeBe2F778AA186e88dCf2FEb8f8231565769C27",

--- a/examples/session-key/src/index.ts
+++ b/examples/session-key/src/index.ts
@@ -1,9 +1,9 @@
 import { createGelatoSmartWalletClient, sponsored } from "@gelatonetwork/smartwallet";
 import { addSession, gelato, removeSession, session } from "@gelatonetwork/smartwallet/accounts";
+import "dotenv/config";
 import { http, type Address, type Hex, createPublicClient, createWalletClient } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { baseSepolia } from "viem/chains";
-import "dotenv/config";
 
 const gelatoApiKey = process.env.GELATO_API_KEY;
 
@@ -39,7 +39,7 @@ const createSession = async (signer: Address, expiry: number) => {
   });
 
   const response = await swc.execute({
-    payment: sponsored(gelatoApiKey),
+    payment: sponsored(),
     calls: [
       // This call creates the session
       // You can execute other calls before or after this
@@ -81,7 +81,7 @@ const main = async () => {
   });
 
   const response = await swc.execute({
-    payment: sponsored(gelatoApiKey),
+    payment: sponsored(),
     calls: [
       {
         to: "0xEEeBe2F778AA186e88dCf2FEb8f8231565769C27",

--- a/examples/sponsored/src/index.ts
+++ b/examples/sponsored/src/index.ts
@@ -42,7 +42,7 @@ const publicClient = createPublicClient({
   console.log("Preparing transaction...");
   const startPrepare = performance.now();
   const preparedCalls = await swc.prepareCalls({
-    payment: sponsored(gelatoApiKey),
+    payment: sponsored(),
     calls: [
       {
         to: "0xEEeBe2F778AA186e88dCf2FEb8f8231565769C27",

--- a/examples/trust-wallet-sponsored/src/index.ts
+++ b/examples/trust-wallet-sponsored/src/index.ts
@@ -44,7 +44,7 @@ const publicClient = createPublicClient({
   console.log("Preparing transaction...");
   const startPrepare = performance.now();
   const preparedCalls = await swc.prepareCalls({
-    payment: sponsored(gelatoApiKey),
+    payment: sponsored(),
     calls: [
       {
         to: "0xEEeBe2F778AA186e88dCf2FEb8f8231565769C27",

--- a/examples/viem-adapter/src/index.ts
+++ b/examples/viem-adapter/src/index.ts
@@ -37,7 +37,7 @@ const client = createPublicClient({
     transport: http()
   }).extend(
     gelatoBundlerActions({
-      payment: sponsored(gelatoApiKey),
+      payment: sponsored(),
       encoding: WalletEncoding.ERC7579
     })
   );

--- a/plugins/react/wagmi/README.md
+++ b/plugins/react/wagmi/README.md
@@ -51,7 +51,7 @@ function YourComponent() {
     data: taskId,
     isPending
   } = useSendTransaction({
-    payment: sponsored(gelatoApiKey)
+    payment: sponsored()
   });
 
   const { data: receipt } = useWaitForTransactionReceipt({

--- a/src/actions/sendPreparedCalls.ts
+++ b/src/actions/sendPreparedCalls.ts
@@ -2,6 +2,7 @@ import type { Chain, Hex, Transport } from "viem";
 import type { SignAuthorizationReturnType } from "viem/accounts";
 
 import type { GelatoSmartAccount } from "../accounts/index.js";
+import { isSponsored } from "../payment/index.js";
 import type { GelatoResponse } from "../relay/index.js";
 import { walletSendPreparedCalls } from "../relay/rpc/index.js";
 import type { WalletPrepareCallsResponse } from "../relay/rpc/interfaces/index.js";
@@ -33,6 +34,10 @@ export async function sendPreparedCalls<
     authorizationList: _authorizationList
   } = parameters;
   const { context } = preparedCalls;
+
+  if (isSponsored(context.payment) && !client._internal.apiKey()) {
+    throw new Error("Invalid sponsored request: No apiKey provided.");
+  }
 
   const signature = _signature ?? (await signSignatureRequest(client, preparedCalls));
   const authorizationList = _authorizationList ?? (await signAuthorizationList(client));

--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -39,8 +39,6 @@ export function gelatoBundlerActions(config: GelatoBundlerConfig) {
   >(
     client: Client<transport, chain, account>
   ): BundlerActions<account> & GelatoUserOperationGasPriceAction => {
-    config.apiKey = (isSponsored(config.payment) && config.payment.apiKey) || config.apiKey;
-
     if (isSponsored(config.payment) && !config.apiKey) {
       throw new Error("apiKey must be provided for sponsored payment");
     }

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -11,8 +11,6 @@ export interface ERC20Payment {
 
 export interface SponsoredPayment {
   readonly type: "sponsored";
-  // Optional, if not provided, the apiKey MUST be provided when instantiating the client
-  readonly apiKey?: string;
 }
 
 export type Payment = NativePayment | ERC20Payment | SponsoredPayment;
@@ -24,9 +22,8 @@ export const erc20 = (token: Address): ERC20Payment => ({
   token
 });
 
-export const sponsored = (apiKey: string): SponsoredPayment => ({
-  type: "sponsored",
-  apiKey
+export const sponsored = (): SponsoredPayment => ({
+  type: "sponsored"
 });
 
 export const isSponsored = (payment: Payment): payment is SponsoredPayment =>

--- a/test/Delegation.test.ts
+++ b/test/Delegation.test.ts
@@ -93,10 +93,9 @@ describe("Initial Delegation Test", () => {
 
   test("Gelato SCW transaction with sponsor payment", async () => {
     const gelatoClient = await createGelatoSmartWalletClient(walletClient, {
-      scw: { type: "gelato" }
+      scw: { type: "gelato" },
+      apiKey: getApiKeyStaging()
     });
-
-    const apiKey = getApiKeyStaging();
 
     const balanceInitial = await gelatoClient.getBalance({
       address: gelatoClient.account.address
@@ -110,7 +109,7 @@ describe("Initial Delegation Test", () => {
     });
 
     const response = await gelatoClient.execute({
-      payment: sponsored(apiKey),
+      payment: sponsored(),
       calls: constants.testCalls,
       nonceKey: 2n
     });


### PR DESCRIPTION
BREAKING CHANGE: 
`apiKey` is removed from sponsored `Payment` object. 
`apiKey` from wallet config is passed as query parameter in wallet RPC during send calls. 
The wallet config `apiKey` is enforced when the payment type is sponsored. 

Old: 
```ts
sponsored(apiKey)
```

Updated:
```ts
sponsored()
```